### PR TITLE
fix Readme: update clone protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is a custom component for Home-Assistant which will add the ability to cont
 ## Git Clone
 You can clone this repo into your `custom_components` folder in your Home Assistant config location with the name `dreamscreen`.
 ```bash
-git clone git@github.com:GregoryDosh/Home-Assistant-DreamScreen-Service.git dreamscreen
+git clone https://github.com/GregoryDosh/Home-Assistant-DreamScreen-Service.git dreamscreen
 ```
 
 ## Git Submodule
 You can also add it as a submodule which will allow you to pull updates in the future using `git submodule foreach git pull`.
 ```bash
-git submodule add -b master git@github.com:GregoryDosh/Home-Assistant-DreamScreen-Service.git dreamscreen
+git submodule add -b master https://github.com/GregoryDosh/Home-Assistant-DreamScreen-Service.git dreamscreen
 ```
 
 


### PR DESCRIPTION
Updating the clone protocol, to allow people that don't have repo write access to clone the repo.

Using the `ssh` protocol will result in the following error:
```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```